### PR TITLE
fix broken locales 1.4.1

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,7 +3,7 @@ browser.WindowListener.registerChromeUrl([
   ["locale",   "folderflags", "bg-BG", "chrome/locale/bg-BG/"],
   ["locale",   "folderflags", "cs-CZ", "chrome/locale/cz-CZ/"],
   ["locale",   "folderflags", "de",    "chrome/locale/de/"],
-  ["locale",   "folderflags", "en-US", "chrome/locale/en-US/"],
+  ["locale",   "folderflags", "en-US", "chrome/locale/en/"],
   ["locale",   "folderflags", "es-ES", "chrome/locale/es-ES/"],
   ["locale",   "folderflags", "it",    "chrome/locale/it/"],
   ["locale",   "folderflags", "ja-JP", "chrome/locale/ja-JP/"],


### PR DESCRIPTION
In order to match the locale and _locales folder, I renamed es-US to en but forgot to change the registration in the WL.